### PR TITLE
Micro SCSS Port

### DIFF
--- a/css/demo.scss
+++ b/css/demo.scss
@@ -1,0 +1,30 @@
+header#top {
+	background-color: black;
+}
+h1 {
+	font-family: Georgia;
+	font-size: 2em;
+	padding: 1em;
+	color: white;
+	
+	a {
+		color: white;
+		text-decoration: none;
+	}
+}
+h2 {
+	font-family: Georgia;
+	font-size: 1.5em;
+	padding: 5.25em 0;
+	color: #666;
+	background-color: #ccc;
+	text-align: center;
+}
+ul#boxes li {
+	font-family: Georgia;
+	font-size: 1.33em;
+	padding: 2.5em 0;
+	color: #999;
+	background-color: #e5e5e5;
+	text-align: center;
+}

--- a/css/grid.scss
+++ b/css/grid.scss
@@ -1,0 +1,35 @@
+// Defaults which you can freely override
+$column-width: 60px;
+$gutter-width: 20px;
+$columns: 12;
+
+// Utility variable — you should never need to modify this
+$_gridsystem-width: ($column-width*$columns) + ($gutter-width*$columns);
+
+// Set $total-width to 100% for a fluid layout
+$total-width: $_gridsystem-width;
+
+
+//////////
+// GRID //
+//////////
+
+body {
+	width: 100%;
+	float: left;
+}
+
+@mixin row($columns:$columns) {
+	display: inline-block;
+	overflow: hidden;
+	width: $total-width*(($gutter-width + $_gridsystem-width)/$_gridsystem-width);
+	margin: 0 $total-width*((($gutter-width*.5)/$_gridsystem-width)*-1);
+}
+
+@mixin column($x,$columns:$columns) {
+	display: inline;
+	float: left;
+	overflow: hidden;
+	width: $total-width*(((($gutter-width+$column-width)*$x)-$gutter-width) / $_gridsystem-width);
+	margin: 0 $total-width*(($gutter-width*.5)/$_gridsystem-width);
+}

--- a/css/reset.scss
+++ b/css/reset.scss
@@ -1,0 +1,48 @@
+/* http://meyerweb.com/eric/tools/css/reset/ 
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}


### PR DESCRIPTION
The other SASS Port is HUGE. This just ports the files that you absolutely need to use semantic.gs in SCSS/SASS. I don't think we need to port all the examples to every single framework. If you can read SASS, you can read Less. No need to burden the maintainers with having to edit dozens of files anytime they update an example!

reset.scss and demo.scss are actually identical to reset.less and demo.less. In fact, reset.less/reset.scss can be made straight reset.css, since it is pure CSS. I haven't done this in my commit, though. Leaving it up to maintainers.
