### PR TITLE
Changed rows from inline-block to block to remove margin at row bottom

### DIFF
--- a/stylesheets/less/grid.less
+++ b/stylesheets/less/grid.less
@@ -24,7 +24,7 @@ body {
 }
 
 .row(@columns:@columns) {
-	display: inline-block;
+	display: block;
 	width: @total-width*((@gutter-width + @_gridsystem-width)/@_gridsystem-width);
 	margin: 0 @total-width*(((@gutter-width*.5)/@_gridsystem-width)*-1);
 	.clearfix;


### PR DESCRIPTION
Changed rows from inline-block to block to remove extra margin at row bottom. The clearfix mixin already does its job.
