### PR TITLE
Fixes for defaults in SCSS and correct fluid column calcs

### DIFF
--- a/stylesheets/scss/grid.scss
+++ b/stylesheets/scss/grid.scss
@@ -36,18 +36,25 @@ body {
 }
 
 @mixin row($columns:$columns) {
+	$_gridsystem-width: ($column-width*$columns) + ($gutter-width*$columns);
 	display: inline-block;
 	width: $total-width*(($gutter-width + $_gridsystem-width)/$_gridsystem-width);
-	margin: 0 $total-width*((($gutter-width*.5)/$_gridsystem-width)*-1);
+	$margin: $total-width*((($gutter-width*.5)/$_gridsystem-width)*-1);
+	margin-left: $margin;
+	margin-right: $margin;
 	@include clearfix();
 }
 @mixin column($x,$columns:$columns) {
+	$_gridsystem-width: ($column-width*$columns) + ($gutter-width*$columns);
 	display: inline;
 	float: left;
 	width: $total-width*(((($gutter-width+$column-width)*$x)-$gutter-width) / $_gridsystem-width);
-	margin: 0 $total-width*(($gutter-width*.5)/$_gridsystem-width);
+	$margin: $total-width*(($gutter-width*.5)/$_gridsystem-width);
+	margin-left: $margin;
+	margin-right: $margin;
 }
 @mixin offset($offset:1) {
+	$_gridsystem-width: ($column-width*$columns) + ($gutter-width*$columns);
 	margin-left: ($gutter-width+$column-width)*$offset + $total-width*(($gutter-width*.5)/$_gridsystem-width);
 }
 


### PR DESCRIPTION
Hi,

I apologize if my pull request is not being done correctly. This is my first ever git-hub pull request.

The way the grid.scss works currently, doesn't work right if you are using sub-columns (inside a row) when in fluid mode. I've made some tweaks to _hopefully_ fix that.

Also, I added some !default declarations to your defaults.

Thanks for putting this framework together! I really like how small and efficient it is!

I hope my changes are helpful.
