### PR TITLE
SCSS $_gridsystem-width fix

### DIFF
--- a/stylesheets/scss/grid.scss
+++ b/stylesheets/scss/grid.scss
@@ -38,19 +38,21 @@ body {
 }
 
 @mixin row($columns:$columns) {
+	margin: 0 (($gutter-width / 2) * -1px);
 	display: inline-block;
-	width: $total-width*(($gutter-width + _gridsystem-width($columns))/_gridsystem-width($columns));
-	margin: 0 $total-width*((($gutter-width*.5)/_gridsystem-width($columns))*-1);
+	width: #{_gridsystem-width($columns)}px;
 	@include clearfix();
 }
-@mixin column($x,$columns:$columns) {
+
+@mixin column($x, $columns:$columns) {
 	display: inline;
 	float: left;
-	width: $total-width * (((($gutter-width+$column-width) * $x) - $gutter-width) / _gridsystem-width($columns));
-	margin: 0 $total-width*(($gutter-width*.5)/_gridsystem-width($columns));
+	width: #{_gridsystem-width($x) - $gutter-width}px;
+	margin: 0 (($gutter-width / 2) * 1px);
 }
+
 @mixin offset($offset:1) {
-	margin-left: ($gutter-width+$column-width)*$offset + $total-width*(($gutter-width*.5)/_gridsystem-width);
+	margin-left: (_gridsystem-width($offset) + ($gutter-width / 2) * 1px);
 }
 
 // The micro clearfix http://nicolasgallagher.com/micro-clearfix-hack/


### PR DESCRIPTION
Hi,

I think I've found an issue with the $_gridsystem-width variable in the SCSS version. It's being treated like a function, but scss doesn't treat it like one. The problem arrises when you nest a row inside a column: The code will attempt to determine the row width using the $_gridsystem-width utility variable, but since scss has already computed this value, it will instead set the row to the same width of the page, $total-width. To solve this I've converted the $_gridsystem-width into a SCSS function, so that whenever _gridsystem-width is called, the correct value will be returned based on the columns specified. 

Thank-you for converting this from less, it's much appreciated, and has been of great help!
Rich 
