### PR TITLE
Parse errors in previous formula.

### DIFF
--- a/stylesheets/styl/grid.styl
+++ b/stylesheets/styl/grid.styl
@@ -16,8 +16,8 @@ total-width = _gridsystem-width
 // Correcting percentage-to-pixel rounding errors in IE6 & 7
 // See http://tylertate.com/blog/2012/01/05/subpixel-rounding.html
 // Override @min with the minimum width of your layout
-min-width: 960;
-correction: 0.5 / min-width * 100 * 1%;
+min-width = 960
+correction = (((0.5 / min-width) * 100) * 1%)
 
 // The micro clearfix http://nicolasgallagher.com/micro-clearfix-hack/
 clearfix()


### PR DESCRIPTION
@min-width: 960;
@correction: 0.5 / @min-width \* 100 \* 1%;

Is less and doesn't work in stylus.
