### PR TITLE
specify `margin-left` and `margin-right` separately

### DIFF
--- a/stylesheets/less/grid.less
+++ b/stylesheets/less/grid.less
@@ -44,7 +44,9 @@ body {
 .row(@columns:@columns) {
 	display: block;
 	width: @total-width*((@gutter-width + @gridsystem-width)/@gridsystem-width);
-	margin: 0 @total-width*(((@gutter-width*.5)/@gridsystem-width)*-1);
+	@margin-width: @total-width*(((@gutter-width*.5)/@gridsystem-width)*-1);
+	margin-left: @margin-width;
+	margin-right: @margin-width;
 	// *width: @total-width*((@gutter-width + @gridsystem-width)/@gridsystem-width)-@correction;
 	// *margin: 0 @total-width*(((@gutter-width*.5)/@gridsystem-width)*-1)-@correction;
 	.clearfix;
@@ -53,7 +55,9 @@ body {
 	display: inline;
 	float: left;
 	width: @total-width*((((@gutter-width+@column-width)*@x)-@gutter-width) / @gridsystem-width);
-	margin: 0 @total-width*((@gutter-width*.5)/@gridsystem-width);
+	@margin-width: @total-width*((@gutter-width*.5)/@gridsystem-width);
+	margin-left: @margin-width;
+	margin-right: @margin-width;
 	// *width: @total-width*((((@gutter-width+@column-width)*@x)-@gutter-width) / @gridsystem-width)-@correction;
 	// *margin: 0 @total-width*((@gutter-width*.5)/@gridsystem-width)-@correction;
 }

--- a/stylesheets/scss/grid.scss
+++ b/stylesheets/scss/grid.scss
@@ -46,7 +46,9 @@ body {
 @mixin row($columns:$columns) {
 	display: block;
 	width: $total-width*(($gutter-width + gridsystem-width($columns))/gridsystem-width($columns));
-	margin: 0 $total-width*((($gutter-width*.5)/gridsystem-width($columns))*-1);
+	$margin-width: $total-width*((($gutter-width*.5)/gridsystem-width($columns))*-1);
+	margin-left: $margin-width;
+	margin-right: $margin-width;
 	// *width: $total-width*(($gutter-width + gridsystem-width($columns))/gridsystem-width($columns))-$correction;
 	// *margin: 0 $total-width*((($gutter-width*.5)/gridsystem-width($columns))*-1)-$correction;
 	@include clearfix();
@@ -55,7 +57,9 @@ body {
 	display: inline;
 	float: left;
 	width: $total-width*(((($gutter-width+$column-width)*$x)-$gutter-width) / gridsystem-width($columns));
-	margin: 0 $total-width*(($gutter-width*.5)/gridsystem-width($columns));
+	$margin-width: $total-width*(($gutter-width*.5)/gridsystem-width($columns));
+	margin-left: $margin-width;
+	margin-right: $margin-width;
 	// *width: $total-width*(((($gutter-width+$column-width)*$x)-$gutter-width) / gridsystem-width($columns))-$correction;
 	// *margin: 0 $total-width*(($gutter-width*.5)/gridsystem-width($columns))-$correction;
 }

--- a/stylesheets/styl/grid.styl
+++ b/stylesheets/styl/grid.styl
@@ -43,7 +43,9 @@ body
 row(columns = columns)
 	display block
 	width total-width * ((gutter-width + _gridsystem-width ) / _gridsystem-width)
-	margin 0 total-width * (((gutter-width * 0.5) / _gridsystem-width ) * - 1)
+	margin-width = total-width * (((gutter-width * 0.5) / _gridsystem-width ) * - 1)
+	margin-left margin-width
+	margin-right margin-width
 	*width total-width * ((gutter-width + _gridsystem-width ) / _gridsystem-width)-correction
 	*margin 0 total-width * (((gutter-width * 0.5) / _gridsystem-width ) * - 1)-correction
 
@@ -52,7 +54,9 @@ column(x, columns = columns)
 	float left
 	overflow hidden
 	width total-width * ((((gutter-width + column-width ) * x) - gutter-width) / _gridsystem-width)
-	margin 0 total-width * ( (gutter-width * 0.5) / _gridsystem-width)
+	margin-width = total-width * ( (gutter-width * 0.5) / _gridsystem-width)
+	margin-left margin-width
+	margin-right margin-width
 	*width total-width * ((((gutter-width + column-width ) * x) - gutter-width) / _gridsystem-width)-correction
 	*margin 0 total-width * ( (gutter-width * 0.5) / _gridsystem-width)-correction
 


### PR DESCRIPTION
I've made a small change so that the grid stylesheets specify `margin-left` and `margin-right` individually rather than using `margin: 0 x`.

I'm using `section` tags for columns and have a rule like this in my _less_ file:

```
section {
    margin-top: @gutter-width * 1px;
}

section#foo {
    .column(8);
}
```

Because the specificity of the id-based selector beats the general tag rule the margin top is never applied as the `.column` mixin overrides it. I didn't want to apply the top margin in the id-based rule as it's the same on every single column element. The only other way I could get it to work without modifying `grid.less` was to add `!important` which is pretty horrible!
