### PR TITLE
fix for Stylus

### DIFF
--- a/stylesheets/styl/grid.styl
+++ b/stylesheets/styl/grid.styl
@@ -3,58 +3,55 @@
 /////////////////
 
 // Defaults which you can freely override
-column-width = 60px
-gutter-width = 20px
+column_width = 60px
+gutter_width = 20px
 columns = 12
 
-// Utility variable — you should never need to modify this
-_gridsystem-width = (column-width + gutter-width) * columns
+// Utility variable - you should never need to modify this
+_gridsystem_width = (column_width + gutter_width) * columns
 
 // Set @total-width to 100% for a fluid layout
-total-width = _gridsystem-width
+total_width = _gridsystem_width
 
 // Correcting percentage-to-pixel rounding errors in IE6 & 7
 // See http://tylertate.com/blog/2012/01/05/subpixel-rounding.html
 // Override @min with the minimum width of your layout
-min-width = 960
-correction = (((0.5 / min-width) * 100) * 1%)
-
-// The micro clearfix http://nicolasgallagher.com/micro-clearfix-hack/
-clearfix()
- *zoom:1
-
-	&:before,
-	&:after
-		content:""
-		display:table
-
-	&:after
-		clear:both
-
+min_width = 960
+correction = (((0.5 / min_width) * 100) * 1%)
 
 //////////
 // GRID //
 //////////
 
 body
-	width 100%
-	clearfix()
+  width 100%
+  clearfix()
 
 row(columns = columns)
-	display block
-	width total-width * ((gutter-width + _gridsystem-width ) / _gridsystem-width)
-	margin 0 total-width * (((gutter-width * 0.5) / _gridsystem-width ) * - 1)
-	*width total-width * ((gutter-width + _gridsystem-width ) / _gridsystem-width)-correction
-	*margin 0 total-width * (((gutter-width * 0.5) / _gridsystem-width ) * - 1)-correction
+  calculated_row_width = total_width * ((gutter_width + _gridsystem_width ) / _gridsystem_width)
+  calculated_margin_width = total_width * (((gutter_width * 0.5) / _gridsystem_width ) * - 1)
+
+  display block
+  width calculated_row_width
+  margin-left calculated_margin_width
+  margin-right calculated_margin_width
+  *width (calculated_row_width - correction)
+  *margin-left: (calculated_margin_width - correction)
+  *margin-right: (calculated_margin_width - correction)
 
 column(x, columns = columns)
-	display inline
-	float left
-	overflow hidden
-	width total-width * ((((gutter-width + column-width ) * x) - gutter-width) / _gridsystem-width)
-	margin 0 total-width * ( (gutter-width * 0.5) / _gridsystem-width)
-	*width total-width * ((((gutter-width + column-width ) * x) - gutter-width) / _gridsystem-width)-correction
-	*margin 0 total-width * ( (gutter-width * 0.5) / _gridsystem-width)-correction
+  calculated_column_width = total_width * ((((gutter_width + column_width) * x) - gutter_width) / _gridsystem_width)
+  calculated_margin_width = total_width * ( (gutter_width * 0.5) / _gridsystem_width)
+
+  display inline
+  float left
+  overflow hidden
+  width calculated_column_width
+  margin-left calculated_margin_width
+  margin-right calculated_margin_width
+  *width (calculated_column_width - correction)
+  *margin-left: (calculated_margin_width - correction)
+  *margin-right: (calculated_margin_width - correction)
 
 offset(offset = 1)
-	margin-left total-width*(((gutter-width+column-width)*offset + (gutter-width*0.5))/_gridsystem-width)
+  margin-left (total_width*(((gutter_width + column_width) * offset + (gutter_width*0.5)) / _gridsystem_width))


### PR DESCRIPTION
this fixes the calculation errors in the Stylus version, I needed to add many brackets since Stylus supports the 10px/12px notation (ex. `font: foo/bar` -> `font: 1em/2em`, `font: (foo/bar)` -> `font: 0.5em`).

I renamed the variables to avoid errors since `-` is an operator
