### PR TITLE
Less 1.4 Compat

### DIFF
--- a/stylesheets/less/grid.less
+++ b/stylesheets/less/grid.less
@@ -8,7 +8,7 @@
 @columns: 12;
 
 // Utility variable — you should never need to modify this
-@gridsystem-width: (@column-width*@columns) + (@gutter-width*@columns) * 1px;
+@gridsystem-width: (((@column-width*@columns) + (@gutter-width*@columns)) * 1px);
 
 // Set @total-width to 100% for a fluid layout
 @total-width: @gridsystem-width;
@@ -43,23 +43,23 @@ body {
 
 .row(@columns:@columns) {
 	display: block;
-	width: @total-width*((@gutter-width + @gridsystem-width)/@gridsystem-width);
-	margin: 0 @total-width*(((@gutter-width*.5)/@gridsystem-width)*-1);
-	// *width: @total-width*((@gutter-width + @gridsystem-width)/@gridsystem-width)-@correction;
-	// *margin: 0 @total-width*(((@gutter-width*.5)/@gridsystem-width)*-1)-@correction;
+	width: (@total-width*((@gutter-width + @gridsystem-width)/@gridsystem-width));
+	margin: 0 (@total-width*(((@gutter-width*.5)/@gridsystem-width)*-1));
+	// *width: (@total-width*((@gutter-width + @gridsystem-width)/@gridsystem-width)-@correction);
+	// *margin: 0 (@total-width*(((@gutter-width*.5)/@gridsystem-width)*-1)-@correction);
 	.clearfix;
 }
 .column(@x,@columns:@columns) {
 	display: inline;
 	float: left;
-	width: @total-width*((((@gutter-width+@column-width)*@x)-@gutter-width) / @gridsystem-width);
-	margin: 0 @total-width*((@gutter-width*.5)/@gridsystem-width);
-	// *width: @total-width*((((@gutter-width+@column-width)*@x)-@gutter-width) / @gridsystem-width)-@correction;
-	// *margin: 0 @total-width*((@gutter-width*.5)/@gridsystem-width)-@correction;
+	width: (@total-width*((((@gutter-width+@column-width)*@x)-@gutter-width) / @gridsystem-width));
+	margin: 0 (@total-width*((@gutter-width*.5)/@gridsystem-width));
+	// *width: (@total-width*((((@gutter-width+@column-width)*@x)-@gutter-width) / @gridsystem-width)-@correction);
+	// *margin: 0 (@total-width*((@gutter-width*.5)/@gridsystem-width)-@correction);
 }
 .push(@offset:1) {
-	margin-left: @total-width*(((@gutter-width+@column-width)*@offset) / @gridsystem-width) + @total-width*((@gutter-width*.5)/@gridsystem-width);
+	margin-left: (@total-width*(((@gutter-width+@column-width)*@offset) / @gridsystem-width) + @total-width*((@gutter-width*.5)/@gridsystem-width));
 }
 .pull(@offset:1) {
-	margin-right: @total-width*(((@gutter-width+@column-width)*@offset) / @gridsystem-width) + @total-width*((@gutter-width*.5)/@gridsystem-width);
+	margin-right: (@total-width*(((@gutter-width+@column-width)*@offset) / @gridsystem-width) + @total-width*((@gutter-width*.5)/@gridsystem-width));
 }

--- a/stylesheets/less/grid.less
+++ b/stylesheets/less/grid.less
@@ -8,7 +8,7 @@
 @columns: 12;
 
 // Utility variable — you should never need to modify this
-@gridsystem-width: (((@column-width*@columns) + (@gutter-width*@columns)) * 1px);
+@gridsystem-width: (((@column-width*@columns) + (@gutter-width*@columns)) * 1);
 
 // Set @total-width to 100% for a fluid layout
 @total-width: @gridsystem-width;

--- a/stylesheets/less/grid.less
+++ b/stylesheets/less/grid.less
@@ -8,7 +8,7 @@
 @columns: 12;
 
 // Utility variable — you should never need to modify this
-@gridsystem-width: (((@column-width*@columns) + (@gutter-width*@columns)) * 1);
+@gridsystem-width: (@column-width*@columns + @gutter-width*@columns);
 
 // Set @total-width to 100% for a fluid layout
 @total-width: @gridsystem-width;


### PR DESCRIPTION
Less 1.4 has a couple of breaking changes; namely, math needs to be wrapped in parens and mixed-unit math is disallowed. So I wrapped all the math in parens.

The one occurrence of mixed-unit math was in the calculation of `@gridsystem-width`. I removed the pixels unit but, honestly, I'm not sure why the value was being multiplied by 1px in the first place. I assumed it was to coerce less into rounding or something, but it didn't seem to be making a difference for me with 1.4 or 1.3.3. Which is just a roundabout way of saying that I'm not sure if b32266d is kosher, or whether something more complicated needs to be done (: Just in case, I kept it as a separate commit.
