### PR TITLE
Add 'container' to center the content in page

### DIFF
--- a/stylesheets/less/grid.less
+++ b/stylesheets/less/grid.less
@@ -41,6 +41,10 @@ body {
 	.clearfix;
 }
 
+.container {
+        margin: 0 (100% - @total-width) / 2;
+}
+
 .row(@columns:@columns) {
 	display: block;
 	width: @total-width*((@gutter-width + @gridsystem-width)/@gridsystem-width);

--- a/stylesheets/scss/grid.scss
+++ b/stylesheets/scss/grid.scss
@@ -43,6 +43,10 @@ body {
 	@include clearfix();
 }
 
+@mixin container {
+        margin: 0 (100% - @total-width) / 2;
+}
+
 @mixin row($columns:$columns) {
 	display: block;
 	width: $total-width*(($gutter-width + gridsystem-width($columns))/gridsystem-width($columns));

--- a/stylesheets/styl/grid.styl
+++ b/stylesheets/styl/grid.styl
@@ -40,6 +40,9 @@ body
 	width 100%
 	clearfix()
 
+container
+        margin: 0 (100% - total-width) / 2
+
 row(columns = columns)
 	display block
 	width total-width * ((gutter-width + _gridsystem-width ) / _gridsystem-width)


### PR DESCRIPTION
I set the `@total-width` as 90% because I want some spacing around the page. The problem is, the element with column(s) will not be horizontally centered.
This `container` mixin solves this problem.

If you think it's improper to introduce a new mixin, maybe we can add the this spacing as horizontal `padding` of  `body`? 
