### PR TITLE
Easier overriding of SCSS defaults

### DIFF
--- a/stylesheets/scss/grid.scss
+++ b/stylesheets/scss/grid.scss
@@ -3,9 +3,9 @@
 /////////////////
 
 // Defaults which you can freely override
-$column-width: 60px;
-$gutter-width: 20px;
-$columns: 12;
+$column-width: 60px !default;
+$gutter-width: 20px !default;
+$columns: 12 !default;
 
 // Utility function — you should never need to modify this
 @function gridsystem-width($columns:$columns) {
@@ -13,7 +13,7 @@ $columns: 12;
 }
 
 // Set $total-width to 100% for a fluid layout
-$total-width: gridsystem-width($columns);
+$total-width: gridsystem-width($columns) !default;
 
 // Uncomment these two lines and the star-hack width/margin lines below to enable sub-pixel fix for IE6 & 7. See http://tylertate.com/blog/2012/01/05/subpixel-rounding.html
 // $min-width: 999999;


### PR DESCRIPTION
Use `!default` for overridable variables in SCSS implementation.
