### PR TITLE
fixes #90: right-to-left language support (LESS only)

### DIFF
--- a/stylesheets/less/grid.less
+++ b/stylesheets/less/grid.less
@@ -56,10 +56,21 @@ body {
 	margin: 0 @total-width*((@gutter-width*.5)/@gridsystem-width);
 	// *width: @total-width*((((@gutter-width+@column-width)*@x)-@gutter-width) / @gridsystem-width)-@correction;
 	// *margin: 0 @total-width*((@gutter-width*.5)/@gridsystem-width)-@correction;
+	[dir="rtl"] & {
+		float: right;
+	}
 }
 .push(@offset:1) {
 	margin-left: @total-width*(((@gutter-width+@column-width)*@offset) / @gridsystem-width) + @total-width*((@gutter-width*.5)/@gridsystem-width);
+	[dir="rtl"] & {
+		margin-left: @total-width*(((@gutter-width*.5)/@gridsystem-width)*-1);
+		margin-right: @total-width*(((@gutter-width+@column-width)*@offset) / @gridsystem-width) + @total-width*((@gutter-width*.5)/@gridsystem-width);
+	}
 }
 .pull(@offset:1) {
 	margin-right: @total-width*(((@gutter-width+@column-width)*@offset) / @gridsystem-width) + @total-width*((@gutter-width*.5)/@gridsystem-width);
+	[dir="rtl"] & {
+		margin-left: @total-width*(((@gutter-width*.5)/@gridsystem-width)*-1);
+		margin-right: @total-width*(((@gutter-width+@column-width)*@offset) / @gridsystem-width) + @total-width*((@gutter-width*.5)/@gridsystem-width);
+	}
 }


### PR DESCRIPTION
These changes add support for right-to-left languages. Just for the LESS pre-processor for now, but porting to the others should be trivial.

Unlike some grid systems that support RTL using a compile-time flag (requiring two separate compiled CSS files), this approach leverages an attribute selector that targets a parent element with the ["dir" attribute](http://www.w3.org/TR/html401/struct/dirlang.html#h-8.2) set to `rtl`. When that attribute/value combination is present, we flip any direction-specific CSS rules (e.g. float, margin-left) to their inverse.

To use the grid system in right-to-left mode, simply add `dir="rtl"` to any parent element in your document:

``` html
<html dir="rtl">
</html>
```
