### PR TITLE
update links to examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,12 +152,12 @@ section {
    .column(3);
 }
 </pre>
-			<p><a href="http://semantic.gs/examples/fixed/fixed.html">The result</a> is two side-by-side columns with the original HTML remaining uncompromised.</p>
+			<p><a href="examples/fixed/fixed.html">The result</a> is two side-by-side columns with the original HTML remaining uncompromised.</p>
 
 			<a id="tutorials"></a>
 			<h2>Tutorials</h2>
 			<h3>Fluid layouts</h3>
-			<p>Semantic.gs can work in either pixels or percentages. While it defaults to pixels, <a href="http://semantic.gs/examples/fluid/fluid.html">fluid layouts</a> can be achieved by adding one additional variable: <code>@total-width: 100%;</code>.</p>
+			<p>Semantic.gs can work in either pixels or percentages. While it defaults to pixels, <a href="examples/fluid/fluid.html">fluid layouts</a> can be achieved by adding one additional variable: <code>@total-width: 100%;</code>.</p>
 <pre>
 @import 'grid.less';
 
@@ -175,7 +175,7 @@ section {
 }
 </pre>		
 			<h3>Responsive layouts</h3>
-			<p>The Semantic Grid, with its clean separation between markup and presentation, is an ideal tool for powering <a href="http://semantic.gs/examples/responsive/responsive.html">adaptive layouts</a> using @media queries.</p>
+			<p>The Semantic Grid, with its clean separation between markup and presentation, is an ideal tool for powering <a href="examples/responsive/responsive.html">adaptive layouts</a> using @media queries.</p>
 <pre>
 article {
    .column(6);
@@ -194,7 +194,7 @@ aside {
 }
 </pre>
 			<h3>Nested columns</h3>
-			<p>Multiple levels of <a href="http://semantic.gs/examples/nested/nested.html">nested columns</a> are no problem — even for fluid layouts. Consider this HTML structure:</p>		
+			<p>Multiple levels of <a href="examples/nested/nested.html">nested columns</a> are no problem — even for fluid layouts. Consider this HTML structure:</p>		
 <pre>
 &lt;article&gt;
    &lt;ul&gt;
@@ -227,7 +227,7 @@ aside {
 }
 </pre>
 			<h3>Push and Pull</h3>
-			<p>The <code>.push()</code> and <code>.pull()</code> mixins allow you apply left and right indents to your columns. Here is an <a href="http://semantic.gs/examples/pushpull/pushpull.html">example page</a>.</p>
+			<p>The <code>.push()</code> and <code>.pull()</code> mixins allow you apply left and right indents to your columns. Here is an <a href="examples/pushpull/pushpull.html">example page</a>.</p>
 <pre>
 // LESS
 article {


### PR DESCRIPTION
Links to the examples were still going to http://semantic.gs. Updated them to relative links 
