### PR TITLE
CNAME file removed to fix url

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-semantic.gs


### PR DESCRIPTION
semantic.gs domain is not working. CNAME file removed for preventing redirection