### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-semantic.gs


### PR DESCRIPTION
Since the domain is expired, I think. And it's redirecting to a driver(?) site, I think it's best to remove this CNAME to avoid github redirecting to semantic.gs.